### PR TITLE
fix(http-client): throw on non-2xx responses so MCP tools surface errors correctly

### DIFF
--- a/src/utils/http-client.test.ts
+++ b/src/utils/http-client.test.ts
@@ -5,3 +5,57 @@ describe("http-client", () => {
     expect(BASE_URL).toBe("https://magic.21st.dev");
   });
 });
+
+describe("http-client error handling", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("throws on non-2xx response with status and error message", async () => {
+    const { twentyFirstClient } = await import("./http-client.js");
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ error: "Anthropic experiencing high load" }), {
+        status: 500,
+        statusText: "Internal Server Error",
+      }) as Response;
+
+    await expect(
+      twentyFirstClient.post("/api/refine-ui", { foo: "bar" })
+    ).rejects.toThrow("HTTP 500 Internal Server Error: {\"error\":\"Anthropic experiencing high load\"}");
+  });
+
+  it("throws on non-2xx response when response has no body", async () => {
+    const { twentyFirstClient } = await import("./http-client.js");
+
+    globalThis.fetch = async () =>
+      new Response(null, {
+        status: 503,
+        statusText: "Service Unavailable",
+      }) as Response;
+
+    await expect(
+      twentyFirstClient.post("/api/refine-ui", { foo: "bar" })
+    ).rejects.toThrow("HTTP 503 Service Unavailable");
+  });
+
+  it("throws on 401 with the error body from server", async () => {
+    const { twentyFirstClient } = await import("./http-client.js");
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ error: "Invalid or inactive API key" }), {
+        status: 401,
+        statusText: "Unauthorized",
+      }) as Response;
+
+    await expect(
+      twentyFirstClient.get("/api/some-endpoint")
+    ).rejects.toThrow("HTTP 401 Unauthorized: {\"error\":\"Invalid or inactive API key\"}");
+  });
+});

--- a/src/utils/http-client.ts
+++ b/src/utils/http-client.ts
@@ -59,6 +59,14 @@ const createMethod = (method: HttpMethod) => {
     });
 
     console.log("response", response);
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      throw new Error(
+        `HTTP ${response.status} ${response.statusText}${errorText ? `: ${errorText}` : ""}`
+      );
+    }
+
     return { status: response.status, data: (await response.json()) as T };
   };
 };


### PR DESCRIPTION
## Summary

Fixes https://github.com/21st-dev/magic-mcp/issues/66

**Before:** `response.ok` was never checked, so server errors (500, 503, etc.) returned as successful tool results with the error text as the output. Example: `/api/refine-ui` returning "Anthropic experiencing high load" as HTTP 200 would appear as a successful refinement to the MCP client — the client could not distinguish an outage from a real refinement.

**After:** `createMethod` now throws an `Error` with the HTTP status and server error body when `response.ok` is false. MCP clients receive a proper error they can surface to the user.

## Changes

- **src/utils/http-client.ts** — after `fetch()`, check `response.ok`. If false, read the response body as text and throw `Error(HTTP {status} {statusText}: {errorText})`. If the body can't be read, fall back to just the status text.
- **src/utils/http-client.test.ts** — 3 new regression tests covering:
  - 500 with JSON error body → full error message in thrown Error
  - 503 with no body → status-only thrown Error
  - 401 with JSON error body → full error message in thrown Error

## Test results

```
PASS src/utils/http-client.test.ts
  http-client
    √ should use production URL in production environment (1 ms)
  http-client error handling
    √ throws on non-2xx response with status and error message (25 ms)
    √ throws on non-2xx response when response has no body (2 ms)
    √ throws on 401 with the error body from server (2 ms)
Tests: 4 passed, 4 total
```
